### PR TITLE
Pull back users correctly when larger than 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
   docker-release:
     name: Docker Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/collector/user.go
+++ b/collector/user.go
@@ -46,14 +46,14 @@ func (rc *UserCollector) Collect(ch chan<- prometheus.Metric) {
 	page := 0
 	for {
 		logrus.WithField("page", page).Traceln("fetching user list from overseerr")
-		users, pageInfo, err := rc.client.GetAllUsers(page, userPageSize)
+		users, pageInfo, err := rc.client.GetAllUsers(userPageSize, page)
 		if err != nil {
 			logrus.WithField("page", page).Errorln("failed to get page of users from overseerr")
 			return
 		}
 		allUsers = append(allUsers, users...)
 		page++
-		if page >= pageInfo.Pages {
+		if page >= (pageInfo.Pages - 1) {
 			break
 		}
 	}


### PR DESCRIPTION
The base library call for [GetAllUsers](https://github.com/WillFantom/goverseerr/blob/main/users.go#L68) has the page size and then the page for the parameter order instead of page/size. Flip those so it pulls the data correctly.

Adjust the if statement to check the page count correctly since the for loop starts at 0 but the page results starts at 1. Subtracting 1 from the `pageInfo.Pages` object will break the loop after the last page.