### PR TITLE
Allow to disable genre/company collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,17 @@ User request counts of an Overseerr server are collected with the following labe
 | :------ | :---------------------------: | -----------: |
 | `email` | The email address of the user |           no |
 
-
 ## Configuration
 
-| Flag                         |                 Description                 | Default    |
-| :--------------------------- | :-----------------------------------------: | :--------- |
-| `log`                        |   Sets the logging level for the exporter   | `fatal`    |
-| `web.listen-address`         |  The address for the exporter to listen on  | `:9850`    |
-| `web.telemetry-path`         |       The path to expose the metrics        | `/metrics` |
-| `overseerr.address`          |      The URI of the Overseerr instance      |            |
-| `overseerr.api-key`          | The admin API key of the Overseerr instance |            |
-| `overseerr.locale`           |    The locale of the Overseerr instance     | `en`       |
-| `overseerr.scrape.genres`    |   Collect genre information for requests    | `true`     |
-| `overseerr.scrape.companies` |  Collect company information for requests   | `true`     |
+| Flag                 |                               Description                               | Default    |
+| :------------------- | :---------------------------------------------------------------------: | :--------- |
+| `log`                |                 Sets the logging level for the exporter                 | `fatal`    |
+| `web.listen-address` |                The address for the exporter to listen on                | `:9850`    |
+| `web.telemetry-path` |                     The path to expose the metrics                      | `/metrics` |
+| `overseerr.address`  |                    The URI of the Overseerr instance                    |            |
+| `overseerr.api-key`  |               The admin API key of the Overseerr instance               |            |
+| `overseerr.locale`   |                  The locale of the Overseerr instance                   | `en`       |
+| `lowCardinality`     | Do not collect genre and company to reduce API requests and cardinality | `false`    |
 
 You **must** provide the Overseerr address and API key!
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,7 @@ var (
 	listenAddress      string
 	metricsPath        string
 	overseerrAPILocale string
-
-	scrapeGenres    bool
-	scrapeCompanies bool
+	lowCardinality     bool
 )
 
 // instance to use
@@ -43,7 +41,7 @@ var RootCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		prometheus.MustRegister(prometheus.NewBuildInfoCollector())
-		prometheus.MustRegister(collector.NewRequestCollector(overseerr, scrapeGenres, scrapeCompanies))
+		prometheus.MustRegister(collector.NewRequestCollector(overseerr, lowCardinality))
 		prometheus.MustRegister(collector.NewUserCollector(overseerr))
 
 		handler := promhttp.Handler()
@@ -87,8 +85,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&overseerrAddress, "overseerr.address", "", "Address at which Overseerr is hosted.")
 	RootCmd.PersistentFlags().StringVar(&overseerrAPIKey, "overseerr.api-key", "", "API key for admin access to the Overseerr instance.")
 	RootCmd.PersistentFlags().StringVar(&overseerrAPILocale, "overseerr.locale", "en", "Locale of the Overseerr instance.")
-	RootCmd.PersistentFlags().BoolVar(&scrapeGenres, "overseerr.scrape.genres", true, "Scrape genere details from the media requests.")
-	RootCmd.PersistentFlags().BoolVar(&scrapeGenres, "overseerr.scrape.companies", true, "Scrape company/network details from the media requests.")
+	RootCmd.PersistentFlags().BoolVar(&lowCardinality, "lowCardinality", true, "Reduce scraping and cardinality on requests count metric.")
 	RootCmd.MarkPersistentFlagRequired("overseerr.address")
 	RootCmd.MarkPersistentFlagRequired("overseerr.api-key")
 


### PR DESCRIPTION
Hi :wave: 

It seems that the `overseerr.scrape.genres` and `overseerr.scrape.companies` flags are not really used, and the code always query the API to get details about requests.
To reduce both API requests and cardinality, I merged them to a single flag that disable collection of genre and company.

I successfully reduced the "requests collection" step from 30 to 4 seconds on my instance by disable this.  