### PR TITLE
Fix a parameters inversion in GetAllUsers function

### DIFF
--- a/collector/user.go
+++ b/collector/user.go
@@ -46,7 +46,7 @@ func (rc *UserCollector) Collect(ch chan<- prometheus.Metric) {
 	page := 0
 	for {
 		logrus.WithField("page", page).Traceln("fetching user list from overseerr")
-		users, pageInfo, err := rc.client.GetAllUsers(page, userPageSize)
+		users, pageInfo, err := rc.client.GetAllUsers(userPageSize, page)
 		if err != nil {
 			logrus.WithField("page", page).Errorln("failed to get page of users from overseerr")
 			return


### PR DESCRIPTION
When calling GetAllUsers function, page number and page size parameters are not in the correct order.